### PR TITLE
Implement command line arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # lsif_indexer
 
-An LSIF indexer for Dart source code. Uses some mechanisms from package:lsif-dart, but
+An [LSIF] indexer for Dart source code. Uses some mechanisms from package:lsif-dart, but
 rewritten from scratch and significantly simpler.
 
 ## Quick Start
@@ -20,3 +20,5 @@ Optionally provide:
 | --- | --- | --- | --- |
 | `output` | `o` | Specify the output file | Terminal standard output |
 | `root` | `r` | Specify the root of the project you are indexing | Current directory |
+
+[LSIF]:https://lsif.dev/

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ $ pub global activate -sgit https://github.com/Workiva/lsif_indexer
 
 Run the indexer on a package:
 ```bash
-$ pub global run lsif_indexer -o output.dump
+$ pub global run lsif_indexer -o dump.lsif
 ```
 
 Optionally provide:

--- a/README.md
+++ b/README.md
@@ -2,3 +2,21 @@
 
 An LSIF indexer for Dart source code. Uses some mechanisms from package:lsif-dart, but
 rewritten from scratch and significantly simpler.
+
+## Quick Start
+
+Activate lsif_indexer:
+```bash
+$ pub global activate -sgit https://github.com/Workiva/lsif_indexer
+```
+
+Run the indexer on a package:
+```bash
+$ pub global run lsif_indexer -o output.dump
+```
+
+Optionally provide:
+| Command | Abbreviation | Description | Default |
+| --- | --- | --- | --- |
+| `output` | `o` | Specify the output file | Terminal standard output |
+| `root` | `r` | Specify the root of the project you are indexing | Current directory |

--- a/bin/lsif_indexer.dart
+++ b/bin/lsif_indexer.dart
@@ -38,24 +38,24 @@ import 'package:lsif_indexer/src/util/path_extensions.dart';
 /// Generate LSIF information for the directory provided from the [arguments], or
 /// the current directory if not specified.
 ///
-/// The format of the output is based on the [arugments].
+/// The destination of the output is based on the [arguments].
 void main(List<String> arguments) async {
-  final config = LsifDartArgumentParser().parse(arguments);
+  final config = ArgumentParser().parse(arguments);
 
   // Exit early if the arguments were invalid
   if (!config.isValid) return;
 
-  if (config.output != null) {
-    emitter = Emitter.fileOutput(config.output);
-  } else {
-    emitter = Emitter.standardOutput();
-  }
+  emitter = config.output == null
+      ? Emitter.standardOutput()
+      : Emitter.fileOutput(config.output);
 
-  await emitter.use(() async {
+  Future<void> _analyze() async {
     await Analyzer(
       packageRoot: config.projectRoot?.absolute?.normalized ??
           Directory.current.absolute.path,
       filesToAnalyze: config.rest.map(absolute).toList(),
     ).analyzePackage();
-  });
+  }
+
+  await emitter.use(_analyze);
 }

--- a/lib/lsif_graph.dart
+++ b/lib/lsif_graph.dart
@@ -32,6 +32,7 @@
 import 'dart:collection';
 import 'dart:convert';
 
+import 'src/emitter.dart';
 import 'src/graph/document.dart';
 import 'src/graph/identifier.dart';
 
@@ -62,9 +63,8 @@ abstract class Element {
   Map<String, Object> toLsif() => {'id': jsonId, 'type': type, 'label': label};
 
   void emit() {
-    // TODO: allow writing to a file
-    var alphabetical = SplayTreeMap<String, Object>()..addAll(toLsif());
-    print(json.encode(alphabetical));
+    final alphabetical = SplayTreeMap<String, Object>()..addAll(toLsif());
+    emitter.emit(json.encode(alphabetical));
   }
 
   @override

--- a/lib/references_visitor.dart
+++ b/lib/references_visitor.dart
@@ -116,7 +116,7 @@ class ReferencesVisitor extends GeneralizingAstVisitor<void> {
     /// Create a reference and the corresponding declaration if it doesn't already exist.
     if (declarationNode is Declaration &&
         !referenceNode.inDeclarationContext()) {
-      var canonical;
+      lsif.Declaration canonical;
       if (declarationElement.source.uri == document.packageUri) {
         declarationNode = narrow(declarationNode);
         var declaration = lsif.Declaration(

--- a/lib/src/arguments.dart
+++ b/lib/src/arguments.dart
@@ -31,9 +31,9 @@ import 'package:args/args.dart';
 import 'package:meta/meta.dart';
 
 /// The resulting config of parsing arguments for the lsif_indexer program.
-class LsifDartConfig {
+class ArgumentConfig {
   /// All arguments that are either options (eg. -o file.ext) or flags (eg. -h).
-  final Map<String, dynamic> options;
+  final Map<String, Object> options;
 
   /// All arguments provided after [options].
   final List<String> rest;
@@ -41,7 +41,7 @@ class LsifDartConfig {
   /// If the command line arguments are valid.
   final bool isValid;
 
-  const LsifDartConfig(this.options, this.rest, {this.isValid = true});
+  const ArgumentConfig(this.options, this.rest, {this.isValid = true});
 
   /// The provided output destination to store the LSIF results in. Can be `null`.
   String get output => _valueForItem(Config.output);
@@ -52,30 +52,26 @@ class LsifDartConfig {
   String _valueForItem(_ConfigItem item) => options[item.name];
 }
 
-class LsifDartArgumentParser {
+class ArgumentParser {
   final ArgParser _argParser;
 
-  LsifDartArgumentParser() : _argParser = ArgParser() {
+  ArgumentParser() : _argParser = ArgParser() {
     _argParser.addItems(Config.all);
   }
 
-  LsifDartConfig parse(List<String> arguments) {
+  ArgumentConfig parse(List<String> arguments) {
     final argResult = _argParser.parse(arguments);
 
     if (argResult['help'] == true) {
       _showHelp();
-      return LsifDartConfig({}, [], isValid: false);
+      return ArgumentConfig({}, [], isValid: false);
     }
 
-    final options = argResult.options.fold(
-      <String, dynamic>{},
-      (accumulator, option) {
-        accumulator[option] = argResult[option];
-        return accumulator;
-      },
-    );
+    final options = <String, Object>{
+      for (final option in argResult.options) option: argResult[option]
+    };
 
-    return LsifDartConfig(options, argResult.rest);
+    return ArgumentConfig(options, argResult.rest);
   }
 
   void _showHelp([String errorMessage]) {
@@ -84,8 +80,9 @@ class LsifDartArgumentParser {
     );
     print(
       'lsif_indexer.dart analyzes all the files of the given project, '
-      'and stores the analyze information in the specified file.',
+      'and stores the analysis information in the specified file in the LSIF format.',
     );
+    print('See https://lsif.dev/ for more information on the LSIF format.\n');
 
     if (errorMessage != null) {
       print('$errorMessage\n');

--- a/lib/src/arguments.dart
+++ b/lib/src/arguments.dart
@@ -1,0 +1,198 @@
+// Copyright 2020 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// --------------------------------------------------
+//
+// This lsif_indexer software is based on a number of software repositories with
+// separate copyright notices and/or license terms. Your use of the source
+// code for the these software repositories is subject to the terms and
+// conditions of the following licenses:
+//
+// lsif-dart: https://github.com/sourcegraph/lsif-dart
+// Copyright Anton Astashov. All rights reserved.
+// Licensed under the BSD-2 Clause License: https://github.com/sourcegraph/lsif-dart/blob/master/LICENSE
+//
+// crossdart: https://github.com/astashov/crossdart
+// Copyright Anton Astashov. All rights reserved.
+// Licensed under the BSD-2 Clause License: https://github.com/astashov/crossdart/blob/master/LICENSE
+
+import 'package:args/args.dart';
+import 'package:meta/meta.dart';
+
+/// The resulting config of parsing arguments for the lsif_indexer program.
+class LsifDartConfig {
+  /// All arguments that are either options (eg. -o file.ext) or flags (eg. -h).
+  final Map<String, dynamic> options;
+
+  /// All arguments provided after [options].
+  final List<String> rest;
+
+  /// If the command line arguments are valid.
+  final bool isValid;
+
+  const LsifDartConfig(this.options, this.rest, {this.isValid = true});
+
+  /// The provided output destination to store the LSIF results in. Can be `null`.
+  String get output => _valueForItem(Config.output);
+
+  /// The provided project root for analysis. Can be `null`.
+  String get projectRoot => _valueForItem(Config.projectRoot);
+
+  String _valueForItem(_ConfigItem item) => options[item.name];
+}
+
+class LsifDartArgumentParser {
+  final ArgParser _argParser;
+
+  LsifDartArgumentParser() : _argParser = ArgParser() {
+    _argParser.addItems(Config.all);
+  }
+
+  LsifDartConfig parse(List<String> arguments) {
+    final argResult = _argParser.parse(arguments);
+
+    if (argResult['help'] == true) {
+      _showHelp();
+      return LsifDartConfig({}, [], isValid: false);
+    }
+
+    final options = argResult.options.fold(
+      <String, dynamic>{},
+      (accumulator, option) {
+        accumulator[option] = argResult[option];
+        return accumulator;
+      },
+    );
+
+    return LsifDartConfig(options, argResult.rest);
+  }
+
+  void _showHelp([String errorMessage]) {
+    print(
+      'LSIF Dart Indexer - A Dart language server index format generator.\n',
+    );
+    print(
+      'lsif_indexer.dart analyzes all the files of the given project, '
+      'and stores the analyze information in the specified file.',
+    );
+
+    if (errorMessage != null) {
+      print('$errorMessage\n');
+    }
+
+    print('Available options:');
+    print(_argParser.usage);
+    print('Optionally provide a list of files to filter the analysis');
+    print('Eg. pub global run lsif_indexer a.dart b.dart c.dart');
+  }
+}
+
+/// The base of anything configurable (options, flags).
+abstract class _ConfigItem<T> {
+  final String name;
+  final String help;
+  final String abbreviation;
+  final T defaultsTo;
+
+  const _ConfigItem({
+    @required this.name,
+    this.help,
+    this.abbreviation,
+    this.defaultsTo,
+  });
+}
+
+/// An option configuration value.
+///
+/// Example: -o <path/to/output.extension>
+class _ConfigOption extends _ConfigItem<String> {
+  const _ConfigOption({
+    @required String name,
+    String help,
+    String abbreviation,
+    String defaultsTo,
+  }) : super(
+          name: name,
+          help: help,
+          abbreviation: abbreviation,
+          defaultsTo: defaultsTo,
+        );
+}
+
+/// A flag configuration value.
+///
+/// Example: -h (true or false)
+class _ConfigFlag extends _ConfigItem<bool> {
+  final bool negatable;
+
+  const _ConfigFlag({
+    @required String name,
+    String help,
+    String abbreviation,
+    this.negatable = true,
+    bool defaultsTo = false,
+  }) : super(
+          name: name,
+          help: help,
+          abbreviation: abbreviation,
+          defaultsTo: defaultsTo,
+        );
+}
+
+class Config {
+  static const help = _ConfigFlag(
+    name: 'help',
+    help: 'Show this message',
+    abbreviation: 'h',
+    negatable: false,
+  );
+  static const output = _ConfigOption(
+    name: 'output',
+    help: 'The output file\n(defaults to standard output)',
+    abbreviation: 'o',
+  );
+  static const projectRoot = _ConfigOption(
+    name: 'root',
+    help: 'The project root input\n(defaults to the current directory)',
+    abbreviation: 'r',
+  );
+
+  static List<_ConfigItem> get all {
+    return [help, output, projectRoot]
+      ..sort((a, b) => a.name.compareTo(b.name));
+  }
+}
+
+extension _ArgParserConfig on ArgParser {
+  void addItem(_ConfigItem item) {
+    if (item is _ConfigOption) {
+      addOption(
+        item.name,
+        help: item.help,
+        abbr: item.abbreviation,
+        defaultsTo: item.defaultsTo,
+      );
+    } else if (item is _ConfigFlag) {
+      addFlag(
+        item.name,
+        help: item.help,
+        abbr: item.abbreviation,
+        negatable: item.negatable,
+        defaultsTo: item.defaultsTo,
+      );
+    }
+  }
+
+  void addItems(List<_ConfigItem> items) => items.forEach(addItem);
+}

--- a/lib/src/emitter.dart
+++ b/lib/src/emitter.dart
@@ -1,0 +1,99 @@
+// Copyright 2020 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// --------------------------------------------------
+//
+// This lsif_indexer software is based on a number of software repositories with
+// separate copyright notices and/or license terms. Your use of the source
+// code for the these software repositories is subject to the terms and
+// conditions of the following licenses:
+//
+// lsif-dart: https://github.com/sourcegraph/lsif-dart
+// Copyright Anton Astashov. All rights reserved.
+// Licensed under the BSD-2 Clause License: https://github.com/sourcegraph/lsif-dart/blob/master/LICENSE
+//
+// crossdart: https://github.com/astashov/crossdart
+// Copyright Anton Astashov. All rights reserved.
+// Licensed under the BSD-2 Clause License: https://github.com/astashov/crossdart/blob/master/LICENSE
+
+import 'dart:io';
+
+/// A form of output for the application.
+///
+/// Examples: [FileOutput], [StandardOutput]
+abstract class OutputType {
+  const OutputType();
+
+  void emit(String value);
+  void dispose() {}
+}
+
+/// An [OutputType] that outputs to a [File].
+class FileOutput extends OutputType {
+  final IOSink _ioSink;
+
+  FileOutput(File file)
+      : _ioSink = file.openWrite(),
+        super();
+
+  @override
+  void emit(String value) => _ioSink.writeln(value);
+
+  @override
+  void dispose() => _ioSink.close();
+}
+
+/// An [OutputType] that outputs to standard output.
+class StandardOutput extends OutputType {
+  const StandardOutput() : super();
+
+  @override
+  void emit(String value) => print(value);
+}
+
+class Emitter {
+  final OutputType _output;
+
+  const Emitter._(this._output);
+
+  /// Creates an [Emitter] instance that outputs to a [File] at [filePath].
+  factory Emitter.fileOutput(String filePath) {
+    return Emitter._(FileOutput(File(filePath)));
+  }
+
+  /// Creates an [Emitter] instance that outputs to standard output.
+  factory Emitter.standardOutput() => Emitter._(StandardOutput());
+
+  /// Appends [value] into the target [_output].
+  void emit(String value) => _output.emit(value);
+
+  /// Cleans up any used resources by [_output].
+  void dispose() => _output.dispose();
+
+  /// Runs [fn] while the target [_output] is open,
+  /// disposing [_output] at the end.
+  ///
+  /// If [fn] throws an [Exception], [_output] will still be disposed of.
+  Future<void> use(Future<void> Function() fn) async {
+    try {
+      await fn();
+    } finally {
+      dispose();
+    }
+  }
+}
+
+/// A global instance of an [Emitter] that anywhere can [Emitter.emit] from
+/// to append to the result of the target output.
+Emitter emitter;

--- a/lib/src/util/path_extensions.dart
+++ b/lib/src/util/path_extensions.dart
@@ -27,35 +27,28 @@
 // Copyright Anton Astashov. All rights reserved.
 // Licensed under the BSD-2 Clause License: https://github.com/astashov/crossdart/blob/master/LICENSE
 
-import 'dart:io';
-import 'package:path/path.dart';
+import 'dart:collection';
 
-import 'package:lsif_indexer/analyzer.dart';
-import 'package:lsif_indexer/src/arguments.dart';
-import 'package:lsif_indexer/src/emitter.dart';
-import 'package:lsif_indexer/src/util/path_extensions.dart';
+import 'package:path/path.dart' as path;
 
-/// Generate LSIF information for the directory provided from the [arguments], or
-/// the current directory if not specified.
-///
-/// The format of the output is based on the [arugments].
-void main(List<String> arguments) async {
-  final config = LsifDartArgumentParser().parse(arguments);
+extension PathExtensions on String {
+  /// Normalizes [this], simplifying it by handling `..`, and `.`, and
+  /// removing redundant path separators whenever possible.
+  ///
+  /// Note that this is *not* guaranteed to return the same result for two
+  /// equivalent input paths. For that, see [path.canonicalize]. Or, if you're using
+  /// paths as map keys, pass [path.equals] and [path.hash] to [HashMap].
+  ///
+  ///     path/./to/..//file.text'.normalized; // -> 'path/file.txt'
+  ///
+  /// See [path.normalize()]
+  String get normalized => path.normalize(this);
 
-  // Exit early if the arguments were invalid
-  if (!config.isValid) return;
-
-  if (config.output != null) {
-    emitter = Emitter.fileOutput(config.output);
-  } else {
-    emitter = Emitter.standardOutput();
-  }
-
-  await emitter.use(() async {
-    await Analyzer(
-      packageRoot: config.projectRoot?.absolute?.normalized ??
-          Directory.current.absolute.path,
-      filesToAnalyze: config.rest.map(absolute).toList(),
-    ).analyzePackage();
-  });
+  /// Creates a new path by appending the given path parts to [path.current].
+  /// Equivalent to [path.join()] with [path.current] as the first argument. Example:
+  ///
+  ///     'path'.absolute; // -> '/your/current/dir/path'
+  ///
+  /// See [path.absolute()]
+  String get absolute => path.absolute(this);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,9 @@ environment:
 
 dependencies:
   analyzer: 0.41.1
+  args: ^1.6.0
   collection: ^1.14.13
+  meta: ^1.0.0
   path: ^1.7.0
   package_config: ^1.9.3
 


### PR DESCRIPTION
## Problem
We want to be able to provide an output file from the application instead of printing to standard output

## Solution
Use the `args` library to specify and parse command line options:
- Allow specifying an output file
- Allow specifying a project root
- Use any of the rest of the arguments to specify dart files to run it on

```bash
~/workspace/lsif_indexer (commandLine) > pub global run lsif_indexer -h
LSIF Dart Indexer - A Dart language server index format generator.

lsif_indexer.dart analyzes all the files of the given project, and stores the analysis information in the specified file in the LSIF format.
See https://lsif.dev/ for more information on the LSIF format.

Available options:
-h, --help      Show this message
-o, --output    The output file
                (defaults to standard output)
-r, --root      The project root input
                (defaults to the current directory)
Optionally provide a list of files to filter the analysis
Eg. pub global run lsif_indexer a.dart b.dart c.dart
```

## Testing Instructions
- [ ] Activate this branch
- [ ] Verify each command line option works as expected
  - [ ] `-o` to specify an output file. Defaults to printing to standard output
  - [ ] `-r` to specify the project root. Defaults to current directory
  - [ ] Any amount of Dart files at the end to only run indexing on those specified (runs on all files if none  are provided)