### PR TITLE
Organize imports

### DIFF
--- a/bin/compare.dart
+++ b/bin/compare.dart
@@ -27,8 +27,8 @@
 // Copyright Anton Astashov. All rights reserved.
 // Licensed under the BSD-2 Clause License: https://github.com/astashov/crossdart/blob/master/LICENSE
 
-import 'dart:io';
 import 'dart:convert';
+import 'dart:io';
 
 /// Compare two LSIF files as graphs.
 ///

--- a/bin/lsif_indexer.dart
+++ b/bin/lsif_indexer.dart
@@ -28,6 +28,7 @@
 // Licensed under the BSD-2 Clause License: https://github.com/astashov/crossdart/blob/master/LICENSE
 
 import 'dart:io';
+
 import 'package:lsif_indexer/analyzer.dart';
 
 /// Generate LSIF information for the directory listed in the first [argument], or

--- a/lib/analyzer.dart
+++ b/lib/analyzer.dart
@@ -29,13 +29,13 @@
 
 import 'dart:io';
 
-import 'package:analyzer/dart/analysis/analysis_context_collection.dart';
 import 'package:analyzer/dart/analysis/analysis_context.dart';
+import 'package:analyzer/dart/analysis/analysis_context_collection.dart';
+import 'package:lsif_indexer/lsif_generator.dart';
+import 'package:lsif_indexer/lsif_graph.dart' as lsif;
+import 'package:lsif_indexer/references_visitor.dart';
 import 'package:package_config/package_config.dart';
 import 'package:path/path.dart' as p;
-import 'package:lsif_indexer/lsif_graph.dart' as lsif;
-import 'package:lsif_indexer/lsif_generator.dart';
-import 'package:lsif_indexer/references_visitor.dart';
 
 /// Analysis results for a package.
 class Analyzer {

--- a/lib/lsif_graph.dart
+++ b/lib/lsif_graph.dart
@@ -35,10 +35,10 @@ import 'dart:convert';
 import 'src/graph/document.dart';
 import 'src/graph/identifier.dart';
 
-export 'src/graph/project.dart';
 export 'src/graph/document.dart';
-export 'src/graph/identifier.dart';
 export 'src/graph/event.dart';
+export 'src/graph/identifier.dart';
+export 'src/graph/project.dart';
 
 /// An element in the graph model, either a vertex or an edge.
 abstract class Element {

--- a/lib/references_visitor.dart
+++ b/lib/references_visitor.dart
@@ -27,10 +27,9 @@
 // Copyright Anton Astashov. All rights reserved.
 // Licensed under the BSD-2 Clause License: https://github.com/astashov/crossdart/blob/master/LICENSE
 
-import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/element.dart';
-
 import 'package:lsif_indexer/lsif_graph.dart' as lsif;
 
 /// Visits the AST and constructs an [lsif.Document] with the [Reference]s and [Declaration]s found.

--- a/lib/src/graph/document.dart
+++ b/lib/src/graph/document.dart
@@ -27,8 +27,8 @@
 // Copyright Anton Astashov. All rights reserved.
 // Licensed under the BSD-2 Clause License: https://github.com/astashov/crossdart/blob/master/LICENSE
 
-import 'package:lsif_indexer/lsif_graph.dart';
 import 'package:analyzer/src/generated/source.dart' show LineInfo;
+import 'package:lsif_indexer/lsif_graph.dart';
 
 /// The document entity in the LSIF graph.
 class Document extends Scope {


### PR DESCRIPTION
In the interests of minimizing irrelevant changes in PRs, this just organizes the imports everywhere using the VSCode Dart extension's auto-organize.