### PR TITLE
Remove deprecated authors field from pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,8 +2,6 @@ name: lsif_indexer
 description: Generate an LSIF index (used by e.g. Sourcegraph) from Dart source files
 version: 0.1.0
 homepage: https://github.com/Workiva/lsif_indexer
-authors:
- - Alan Knight <alan.knight@workiva.com>
 
 environment:
   sdk: '>=2.7.0 <3.0.0'


### PR DESCRIPTION
This PR removes the author field from any `pubspec.yaml` files in this repo,
as the field was deprecated in Dart 2.7 and is no longer needed.

Removing this field will silence the warning that `pub publish` emits, which
has the added benefit of allowing us to use `pub publish --dry-run` as a
quality check during CI.

If you'd like to retain the author information, we recommend adding an
`AUTHORS.md` file in the repo or the package directory.

---

This PR was created automatically from a Sourcegraph batch change.
Please reach out to @evanweible-wf or #support-client-plat with any questions.

[_Created by Sourcegraph batch change `Workiva/remove_pubspec_authors`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/batch-changes/remove_pubspec_authors)