### PR TITLE
Support cascades

### DIFF
--- a/lib/references_visitor.dart
+++ b/lib/references_visitor.dart
@@ -66,8 +66,16 @@ class ReferencesVisitor extends GeneralizingAstVisitor<void> {
     if (node.parent is CompoundAssignmentExpression) {
       // Shouldn't the type be inferred here, so the cast wouldn't be required??
       var assignmentNode = node.parent as CompoundAssignmentExpression;
+
       return assignmentNode.readElement ?? assignmentNode.writeElement;
     }
+
+    if (node.parent.parent is AssignmentExpression) {
+      final assignment = node.parent.parent as AssignmentExpression;
+
+      return assignment.readElement ?? assignment.writeElement;
+    }
+
     return null;
   }
 }


### PR DESCRIPTION
https://github.com/Workiva/lsif_indexer/issues/23

## Problem
Cascades didn't appear to be getting indexed

## Solution
Include a check in the `ReferencesVisitor` to return the `Element` associated with them