### PR TITLE
Support SDK References

### DIFF
--- a/lib/references_visitor.dart
+++ b/lib/references_visitor.dart
@@ -118,7 +118,7 @@ class AstReference {
       _localDeclaration ??= _findLocalDeclaration();
 
   lsif.LocalDeclaration _findLocalDeclaration() {
-    if (!declaringElement.isLocaTo(document)) return null;
+    if (!_isLocal(declaringElement)) return null;
 
     return _declare(declaringNode);
   }
@@ -180,8 +180,16 @@ class AstReference {
     return declarationNode;
   }
 
+  /// Is this element part of the current library.
+  // TODO: I don't think this is right. We are treating references from other libraries
+  // in the same package as cross-package references. I think it works, but we should probably avoid.
+  bool _isLocal(Element element) => element.source.uri == document.packageUri;
+
+  /// Does this element come from the Dart SDK.
+  bool _isSdk(Element element) => element.library.identifier.startsWith('dart');
+
   lsif.ImportedDeclaration externalDeclarationFor(Element element) {
-    final packagePrefix = element.isSdk ? 'dart' : 'package';
+    final packagePrefix = _isSdk(element) ? 'dart' : 'package';
 
     final packageName =
         Uri.parse(element.library.identifier).pathSegments.first;

--- a/lib/src/graph/utilities.dart
+++ b/lib/src/graph/utilities.dart
@@ -27,9 +27,6 @@
 // Copyright Anton Astashov. All rights reserved.
 // Licensed under the BSD-2 Clause License: https://github.com/astashov/crossdart/blob/master/LICENSE
 
-import 'package:analyzer/dart/element/element.dart';
-import 'package:lsif_indexer/lsif_graph.dart' as lsif;
-
 extension SetUtilities<T> on Set<T> {
   /// Add [element] if we don't already have an equal
   /// member, and return either [element] or the existing member.
@@ -42,14 +39,4 @@ extension SetUtilities<T> on Set<T> {
       return existing;
     }
   }
-}
-
-extension ElementSource on Element {
-  /// Is this element part of the current library.
-  // TODO: I don't think this is right. We are treating references from other libraries
-  // in the same package as cross-package references. I think it works, but we should probably avoid.
-  bool isLocaTo(lsif.Document document) => source.uri == document.packageUri;
-
-  /// Does this element come from the Dart SDK.
-  bool get isSdk => library.identifier.startsWith('dart');
 }

--- a/lib/src/graph/utilities.dart
+++ b/lib/src/graph/utilities.dart
@@ -27,6 +27,9 @@
 // Copyright Anton Astashov. All rights reserved.
 // Licensed under the BSD-2 Clause License: https://github.com/astashov/crossdart/blob/master/LICENSE
 
+import 'package:analyzer/dart/element/element.dart';
+import 'package:lsif_indexer/lsif_graph.dart' as lsif;
+
 extension SetUtilities<T> on Set<T> {
   /// Add [element] if we don't already have an equal
   /// member, and return either [element] or the existing member.
@@ -39,4 +42,14 @@ extension SetUtilities<T> on Set<T> {
       return existing;
     }
   }
+}
+
+extension ElementSource on Element {
+  /// Is this element part of the current library.
+  // TODO: I don't think this is right. We are treating references from other libraries
+  // in the same package as cross-package references. I think it works, but we should probably avoid.
+  bool isLocaTo(lsif.Document document) => source.uri == document.packageUri;
+
+  /// Does this element come from the Dart SDK.
+  bool get isSdk => library.identifier.startsWith('dart');
 }


### PR DESCRIPTION
https://github.com/Workiva/lsif_indexer/issues/20

## Problem
SDK References were not being included in the LSIF

## Solution
Include them, and use a `dart:` prefix instead of `package:`