### PR TITLE
Update the formatting of tooltips

### DIFF
--- a/lib/references_visitor.dart
+++ b/lib/references_visitor.dart
@@ -124,13 +124,16 @@ class AstReference {
 
   lsif.LocalDeclaration _declare(AstNode node) {
     var narrowed = narrow(node);
+
     var declaration = lsif.LocalDeclaration(
-        document: document,
-        name: declaringElement.displayName,
-        offset: narrowed.offset,
-        end: narrowed.end,
-        docString: declaringElement.documentationComment,
-        location: declaringElement.location.encoding);
+      document: document,
+      name: declaringElement.displayName,
+      offset: narrowed.offset,
+      end: narrowed.end,
+      docString: declaringElement.documentationComment,
+      location: declaringElement.location.encoding,
+      declaration: declaringElement.getDisplayString(withNullability: false),
+    );
 
     return document.addDeclaration(declaration);
   }
@@ -191,13 +194,18 @@ class AstReference {
     if (_isLocal(element) || _isSdk(element)) {
       return null;
     }
-    var hover =
-        element.documentationComment ?? element.getExtendedDisplayName(null);
+
     // TODO: Is the assumption that the package follows this form correct? It won't be for
     // SDK references or special Dart URI schemes for non-lib references.
     var packageName = Uri.parse(element.library.identifier).pathSegments.first;
     var declaration = lsif.ImportedDeclaration(
-        element.location.encoding, 'package:$packageName', hover, document);
+      element.location.encoding,
+      'package:$packageName',
+      element.documentationComment,
+      document,
+      element.getDisplayString(withNullability: false),
+    );
+
     return document.externalDeclarations.addIfAbsent(declaration);
   }
 }

--- a/lib/src/graph/identifier.dart
+++ b/lib/src/graph/identifier.dart
@@ -201,13 +201,15 @@ class HoverResult extends Vertex {
   /// docString (eg. `/// The declaration for the element associated to this hover.`)
   @override
   Map<String, Object> toLsif() {
+    final hoverTexts = [package, declaration, docString];
+
     return {
       ...super.toLsif(),
       'result': {
-        'contents': [package, declaration, docString]
-            .whereNotNull()
-            .map((text) => {'language': 'dart', 'value': text})
-            .toList(),
+        'contents': [
+          for (final text in hoverTexts)
+            if (text != null) {'language': 'dart', 'value': text}
+        ],
       },
     };
   }

--- a/lib/src/graph/utilities.dart
+++ b/lib/src/graph/utilities.dart
@@ -40,3 +40,13 @@ extension SetUtilities<T> on Set<T> {
     }
   }
 }
+
+extension IterableUtilities<T> on Iterable<T> {
+  /// Returns a lazy [Iterable] containing all elements that are not `null`.
+  ///
+  /// Example:
+  /// ```Dart
+  /// [0, null, 1].whereNotNull(); // => (0, 1)
+  /// ```
+  Iterable<T> whereNotNull() => where((element) => element != null);
+}

--- a/lib/src/graph/utilities.dart
+++ b/lib/src/graph/utilities.dart
@@ -40,13 +40,3 @@ extension SetUtilities<T> on Set<T> {
     }
   }
 }
-
-extension IterableUtilities<T> on Iterable<T> {
-  /// Returns a lazy [Iterable] containing all elements that are not `null`.
-  ///
-  /// Example:
-  /// ```Dart
-  /// [0, null, 1].whereNotNull(); // => (0, 1)
-  /// ```
-  Iterable<T> whereNotNull() => where((element) => element != null);
-}


### PR DESCRIPTION
https://github.com/Workiva/lsif_indexer/issues/22

## Problem
Sourcegraph doesn't seem to handle the `markdown` content kind, so newlines are not respected

## Solution
Style all of the hover tooltip as `Dart` code, include:
  - Package the member comes from (except if declared in the same file)
  - The definition of the member
  - The docstring associated to the member (if one exists)